### PR TITLE
Fixed internal bugs and stdout messages.

### DIFF
--- a/splmysql/README.md
+++ b/splmysql/README.md
@@ -39,13 +39,13 @@ It's ok, execute query.
 ```golang
 // Create session. Runner connect to DB and get table information.
 // If connection information has invalid parameters, error returns. 
-sess, err := sr.NewSession(sql)
+sessionData, err := sr.NewSession(sql)
 if err != nil {
     return err
 }
 
 // Let's execute parallel
-retrySessionData, err := sess.RunParallel(numberOfParallel)
+retrySessionData, err := sr.RunParallel(sessionData, numberOfParallel)
 ```
 
 `RunParallel()` returns Session object `retrySessionData` to retry failed queries.

--- a/splmysql/result.go
+++ b/splmysql/result.go
@@ -1,0 +1,48 @@
+package splmysql
+
+// Result is struct of SQL execution result.
+type Result struct {
+	// Plan is number of estimated to execute
+	Plan int64
+	// Executed is number of queries executed to DB.
+	Executed int64
+	// Succeeded is number of queries succeeded.
+	Succeeded int64
+	// Failed is number of queries failed.
+	Failed int64
+	// RowsAffected is number of rows updated.
+	RowsAffected int64
+	// LastInsertID is auto_increment last id. Not used in this implementation.
+	//LastInsertID int64
+}
+
+// NewResult returns struct of New Result
+func NewResult(plan int64) Result {
+	return Result{
+		Plan:         plan,
+		Executed:     0,
+		Succeeded:    0,
+		Failed:       0,
+		RowsAffected: 0,
+	}
+}
+
+// Copy returns self copy struct
+func (r *Result) Copy() Result {
+	return Result{
+		Plan:         r.Plan,
+		Executed:     r.Executed,
+		Succeeded:    r.Succeeded,
+		Failed:       r.Failed,
+		RowsAffected: r.RowsAffected,
+	}
+}
+
+// Append appends another Result.
+func (r *Result) Append(result Result) {
+	r.Plan += result.Plan
+	r.Executed += result.Executed
+	r.Succeeded += result.Succeeded
+	r.Failed += result.Failed
+	r.RowsAffected += result.RowsAffected
+}

--- a/splmysql/result_test.go
+++ b/splmysql/result_test.go
@@ -1,0 +1,44 @@
+package splmysql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopy(t *testing.T) {
+	a := NewResult(1)
+	a.Executed = 2
+	a.Succeeded = 3
+	a.Failed = 4
+	a.RowsAffected = 5
+
+	b := a.Copy()
+	b.Plan = 6
+	b.Executed = 7
+	b.Succeeded = 8
+	b.Failed = 9
+	b.RowsAffected = 10
+
+	assert.NotEqual(t, a.Plan, b.Plan)
+	assert.NotEqual(t, a.Executed, b.Executed)
+	assert.NotEqual(t, a.Succeeded, b.Succeeded)
+	assert.NotEqual(t, a.Failed, b.Failed)
+	assert.NotEqual(t, a.RowsAffected, b.RowsAffected)
+}
+
+func TestAppend(t *testing.T) {
+	a := NewResult(0)
+	b := NewResult(1)
+	b.Executed = 2
+	b.Succeeded = 3
+	b.Failed = 4
+	b.RowsAffected = 5
+	a.Append(b)
+
+	assert.Equal(t, a.Plan, int64(1))
+	assert.Equal(t, a.Executed, int64(2))
+	assert.Equal(t, a.Succeeded, int64(3))
+	assert.Equal(t, a.Failed, int64(4))
+	assert.Equal(t, a.RowsAffected, int64(5))
+}

--- a/splmysql/session.go
+++ b/splmysql/session.go
@@ -1,13 +1,9 @@
 package splmysql
 
-import (
-	"fmt"
-	"sync"
-)
+import "sync"
 
 // Session is a data of splmysql parallel execution
 type Session struct {
-	runner                   *Runner
 	Query                    string
 	DBName                   string
 	TableName                string
@@ -29,6 +25,7 @@ type Transaction struct {
 	rangeEnd   int64
 }
 
+// GetSessionResult returns copy of session result data.
 func (sess *Session) GetSessionResult() Result {
 	sess.mutexResult.RLock()
 	defer sess.mutexResult.RUnlock()
@@ -47,89 +44,19 @@ func (sess *Session) GetFailedTransactions() []*Transaction {
 	return transactions
 }
 
-// updateResult updates sessionResult and Runner's TotalResult.
-func (sess *Session) updateResult(err error, id int64, rowsAffected int64) error {
+// updateResult updates sessionResult.
+func (sess *Session) updateResult(err error, rowsAffected int64) error {
 	sess.mutexResult.Lock()
 	defer sess.mutexResult.Unlock()
 
 	if err != nil {
-		// update result
 		sess.result.Executed++
 		sess.result.Failed++
 		return err
 	}
 
-	// update result
 	sess.result.Executed++
 	sess.result.Succeeded++
 	sess.result.RowsAffected += rowsAffected
-	// print result
-	sess.runner.infof("[%d] - Affected %d rows, total %d updated.", id, rowsAffected, sess.result.RowsAffected)
 	return nil
-}
-
-func (sess *Session) RunParallel(parallel int) (retrySessionData Session, err error) {
-	sr := sess.runner
-
-	// append Session
-	sr.Sessions = append(sr.Sessions, sess)
-
-	semaphore := make(chan struct{}, parallel)
-	sr.db.SetMaxIdleConns(parallel)
-	sr.db.SetMaxOpenConns(parallel)
-	sr.db.SetConnMaxLifetime(0)
-
-	sr.infof("[%s.%s] Session start", sess.DBName, sess.TableName)
-
-	var wg sync.WaitGroup
-	for _, transaction := range sess.transactions {
-		wg.Add(1)
-		semaphore <- struct{}{}
-		go func(tx *Transaction) error {
-			defer wg.Done()
-
-			start := tx.rangeStart
-			end := tx.rangeEnd
-			updateSQL := getSplittedUpdateSQL(sess.Query, sess.SplittableColumn, start, end)
-			sr.tracef("- (%d) update (range: %s = %d - %d) start",
-				tx.id, sess.SplittableColumn, start, end)
-
-			rowsAffected, _, err := sr.doUpdate(updateSQL)
-			tx.completed = true
-			if err != nil {
-				sr.warnf("- (%d) ERROR: %s", tx.id, err.Error())
-				tx.failed = true
-			}
-			sess.updateResult(err, tx.id, rowsAffected)
-			<-semaphore
-			return nil
-		}(transaction)
-	}
-	wg.Wait()
-	close(semaphore)
-	sr.infof("[%s.%s] Session end", sess.DBName, sess.TableName)
-
-	r := sess.GetSessionResult()
-	if r.Failed > 0 {
-		retrySessionData = Session{
-			runner:                   sess.runner,
-			Query:                    sess.Query,
-			DBName:                   sess.DBName,
-			TableName:                sess.TableName,
-			SplittableColumn:         sess.SplittableColumn,
-			SplittableColumnMinValue: sess.SplittableColumnMinValue,
-			SplittableColumnMaxValue: sess.SplittableColumnMaxValue,
-			SplitRange:               sess.SplitRange,
-			transactions:             sess.GetFailedTransactions(),
-			result:                   NewResult(int64(len(sess.GetFailedTransactions()))),
-		}
-		err = fmt.Errorf("[%s.%s] %d transactions failed\n", sess.DBName, sess.TableName, r.Failed)
-		return
-	}
-
-	sr.infof("[%s.%s] Total %d rows updated.", sess.DBName, sess.TableName, r.RowsAffected)
-	sr.infof("[%s.%s] Executed %d queries: %d succeeded, %d failed.",
-		sess.DBName, sess.TableName, r.Executed, r.Succeeded, r.Failed)
-
-	return
 }

--- a/version.go
+++ b/version.go
@@ -1,4 +1,4 @@
 package main
 
 // Version is split_mysql CLI tool version
-const Version = "0.0.1"
+const Version = "0.0.2"


### PR DESCRIPTION
* Fix: stdout messages are mistaken due to following bugs.
* Fix: `Session.RunParallel()` did not return pointer of `Session`.
* Change: `Session.RunParallel()` was the cause of confusion, moving it to `Runner`.
* Add: testcode.